### PR TITLE
Fixes stamina being tied to framerate.

### DIFF
--- a/source/server/customdefs.qc
+++ b/source/server/customdefs.qc
@@ -59,11 +59,18 @@ entity activator;
 .float zoom;
 #endif
 
+float sprint_max_time = 4.0;
 .float sprinting;
 .float weaponskin;
 .float secondaryweaponskin;
 .float thirdweaponskin;
 .float stamina;
+.float sprint_timer;
+.float sprint_duration;
+.float sprint_timer_stopped;
+.float sprint_start_time;
+.float sprint_stop_time;
+.float sprint_rest_time;
 void() W_SprintStop;
 .float into_sprint;
 .float dive;

--- a/source/server/player.qc
+++ b/source/server/player.qc
@@ -361,6 +361,8 @@ void() PlayerPostThink =
 	}
 
 	if (self.sprinting) {
+		self.sprint_timer = self.sprint_duration + (time - self.sprint_start_time);
+		
 		#ifndef PC
 		if (!self.velocity || self.stance != 2) {
 			W_SprintStop();
@@ -371,35 +373,20 @@ void() PlayerPostThink =
 		}
 		#endif
 		
-		// Act differently depending on PC vs others
-		// FTE Frametime never gives a consistent result, especially
-		// in higher framerates w/o vysnc, but fabs(cos(frametime))
-		// is the closest we will get to always returning '1'.
-		#ifdef PC
 		if (self.perks & P_STAMIN) {
-			self.stamina -= 0.015 * fabs(cos(frametime));
-		} else {
-			self.stamina -= 0.03 * fabs(cos(frametime));
+			if (self.sprint_timer > sprint_max_time * 2) {
+				W_SprintStop();
+			}
 		}
-		#else
-		if (self.perks & P_STAMIN) {
-			self.stamina = self.stamina - 0.015;
-		} else { 
-			self.stamina = self.stamina - 0.03;
-		} 
-		#endif
+		else
+		{
+			if (self.sprint_timer > sprint_max_time) {
+				W_SprintStop();
+			}
+		}
 
-		if (self.stamina <= 0) {
-			W_SprintStop();
-		}
-	} else if (self.stamina < 3) 	{
-		#ifndef PC
-		self.stamina = self.stamina + 10*frametime;
-		#else 
-		self.stamina += 10 * fabs(cos(frametime));
-		#endif
-	} else {
-		self.stamina = 3;
+	} else if (self.sprint_duration > 0.0) 	{
+		self.sprint_rest_time = (time - self.sprint_stop_time);
 	}
 
 	self.oldvelocity = self.velocity;

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -77,6 +77,9 @@ void() W_AimOut =
 
 void() W_SprintStop =
 {
+	self.sprint_stop_time = time;
+	self.sprint_duration = self.sprint_timer;
+	
 	float startframe = GetFrame(self.weapon,SPRINT_OUT_START);
 	float endframe = GetFrame(self.weapon,SPRINT_OUT_END);
 	string modelname = GetWeaponModel(self.weapon, 0);
@@ -101,6 +104,12 @@ void() W_SprintStop =
 
 
 void W_SprintStart () {	
+	self.sprint_start_time = time;
+	
+	if (self.sprint_rest_time > sprint_max_time)
+		self.sprint_duration = 0.0;
+	else
+		self.sprint_duration -= self.sprint_rest_time;
 
 #ifdef NX
 	if (!self.sprintflag) {


### PR DESCRIPTION
Players have an internal timer that keeps track on how long the player has been running. The amount of time a player can run is 4 seconds, since in World At War it's exactly 4 seconds. Can be tweaked if necessary.